### PR TITLE
This policy belongs in the bangs theme, not core.

### DIFF
--- a/lib/Perl/Critic/Policy/Bangs/ProhibitBitwiseOperators.pm
+++ b/lib/Perl/Critic/Policy/Bangs/ProhibitBitwiseOperators.pm
@@ -19,7 +19,7 @@ Readonly::Scalar my $EXPL => q{Use of bitwise operator};
 
 sub supported_parameters { return ()                     }
 sub default_severity     { return $SEVERITY_HIGHEST      }
-sub default_themes       { return qw( core bugs )        }
+sub default_themes       { return qw( bangs bugs )        }
 sub applies_to           { return 'PPI::Token::Operator' }
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
All the other policies seem to already be in the bangs theme.  So this was probably just an oversight
