### PR TITLE
Add a new policy ProhibitDebuggingModules

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ lib/Perl/Critic/Policy/Bangs/ProhibitNumberedNames.pm
 lib/Perl/Critic/Policy/Bangs/ProhibitRefProtoOrProto.pm
 lib/Perl/Critic/Policy/Bangs/ProhibitUselessRegexModifiers.pm
 lib/Perl/Critic/Policy/Bangs/ProhibitVagueNames.pm
+lib/Perl/Critic/Policy/Bangs/ProhibitDebuggingModules.pm
 
 Changes
 Makefile.PL
@@ -28,6 +29,7 @@ t/99_pod_coverage.t
 
 t/Bangs/ProhibitBitwiseOperators.run
 t/Bangs/ProhibitCommentedOutCode.run
+t/Bangs/ProhibitDebuggingModules.run
 t/Bangs/ProhibitFlagComments.run
 t/Bangs/ProhibitNoPlan.run
 t/Bangs/ProhibitNumberedNames.run

--- a/ProhibitDebuggingModules.pm
+++ b/ProhibitDebuggingModules.pm
@@ -1,0 +1,1 @@
+lib/Perl/Critic/Policy/Bangs/ProhibitDebuggingModules.pm

--- a/lib/Perl/Critic/Policy/Bangs/ProhibitDebuggingModules.pm
+++ b/lib/Perl/Critic/Policy/Bangs/ProhibitDebuggingModules.pm
@@ -1,0 +1,85 @@
+package Perl::Critic::Policy::Bangs::ProhibitDebuggingModules;
+use strict;
+use warnings;
+
+our $VERSION = '1.07_01';
+
+use List::MoreUtils qw(any);
+use Readonly;
+use Perl::Critic::Utils qw( :severities );
+use base qw(Perl::Critic::Policy);
+
+=head1 NAME
+
+Perl::Critic::Policy::Bangs::ProhibitDebuggingModules - Prohibit loading of debugging modules like Data::Dumper
+
+=head1 DESCRIPTION
+
+This policy prohibits loading common debugging modules like L<Data::Dumper>.
+
+While such modules are incredibly useful during development and debugging,
+they should probably not be loaded in production use. If this policy is
+violated, it probably means you forgot to remove a C<use Data::Dumper;> line
+that you had added when you were debugging.
+
+=head1 CONFIGURATION
+
+The current list of detected debugging modules is:
+
+=over 4
+
+=item * L<Data::Dumper>
+
+=item * L<Data::Printer>
+
+=back
+
+To add more modules that shouldn't be loaded unless you're actively debugging
+something, add them in F<.perlcriticrc> using the C<deubgging_modules> option.
+
+=head1 AFFILIATION
+
+This policy is part of L<Perl::Critic::Bangs>.
+
+=head1 AUTHOR
+
+Mike Doherty C<doherty@cpan.org>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2012 Mike doherty
+
+This library is free software; you can redistribute it and/or modify
+it under the terms of the Artistic License 2.0.
+
+=cut
+
+Readonly::Scalar my $DESC => q/Debugging module loaded/;
+
+sub supported_parameters    {
+    return (
+        {
+            name            => 'debugging_modules',
+            description     => 'Module names which are considered to be banned debugging modules',
+            behavior        => 'string list',
+            list_always_present_values => [qw( Data::Dumper Data::Printer )],
+        }
+    );
+}
+sub default_severity        { $SEVERITY_HIGH }
+sub default_themes          { qw/ bangs maintenance / }
+sub applies_to              { 'PPI::Statement::Include' }
+
+sub violates {
+    my ($self, $include, undef) = @_;
+    return unless defined $include->type and $include->type =~ m/use|require/;
+    my $included = $include->module or return;
+    my $EXPL = "You've loaded $included, which probably shouln't be loaded in production";
+
+    my @banned = ( keys %{ $self->{_debugging_modules} } );
+    return $self->violation($DESC, $EXPL, $include)
+        if any { $included eq $_ } @banned;
+    return;
+}
+
+1;

--- a/t/14_policy_parameters.t
+++ b/t/14_policy_parameters.t
@@ -11,7 +11,7 @@ use Perl::Critic::PolicyParameter qw{ $NO_DESCRIPTION_AVAILABLE };
 use Perl::Critic::Utils qw( policy_short_name );
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 
-use Test::More tests => 12;
+use Test::More tests => 14;
 
 Perl::Critic::TestUtils::block_perlcriticrc();
 

--- a/t/Bangs/ProhibitDebuggingModules.run
+++ b/t/Bangs/ProhibitDebuggingModules.run
@@ -1,0 +1,37 @@
+## name Basic configuration - passes
+## failures 0
+## cut
+
+use Test::More;
+use strict;
+require warnings;
+use 5.8.8;
+require 5.8.8;
+
+## name Basic configuration - fail
+## failures 2
+## cut
+
+require Data::Dumper;
+use Data::Dumper 1;
+
+
+#### Once more with <s>feeling</s> configuration!
+## name With configuration - passes
+## failures 0
+## parms { debugging_modules => 'strict' }
+## cut
+
+use Test::More;
+require warnings;
+use 5.8.8;
+require 5.8.8;
+
+## name With configuration - fail
+## failures 3
+## parms { debugging_modules => 'strict' }
+## cut
+
+use strict;
+require Data::Dumper;
+use Data::Dumper 1;


### PR DESCRIPTION
This policy prohibits loading debugging modules like `Data::Dumper` and `Data::Printer`. While these are incredibly useful for debugging and development, they normally shouldn't be used in production. If this policy is violated, it probably means you forgot to remove a `use Data::Dumper` line you added when you were debugging something.

Resolves [RT #79020](https://rt.cpan.org/Public/Bug/Display.html?id=79020) for Perl-Critic-Bangs: Add a policy for detecting debug modules
