### PR TITLE
ProhibitFlagComments: Limit to only words

### DIFF
--- a/lib/Perl/Critic/Policy/Bangs/ProhibitFlagComments.pm
+++ b/lib/Perl/Critic/Policy/Bangs/ProhibitFlagComments.pm
@@ -31,7 +31,7 @@ sub violates {
     my ( $self, $elem, $doc ) = @_;
 
     foreach my $keyword ( keys %{ $self->{'_keywords'} } ) {
-        if ( index( $elem->content(), $keyword ) != -1 ) { ## no critic (ProhibitMagicNumbers)
+        if ( $elem->content() =~ /\b\Q$keyword\E\b/ ) {
             my $desc = qq(Flag comment '$keyword' found);
             my $expl = qq(Comments containing "$keyword" typically indicate bugs or problems that the developer knows exist);
             return $self->violation( $desc, $expl, $elem );

--- a/t/Bangs/ProhibitFlagComments.run
+++ b/t/Bangs/ProhibitFlagComments.run
@@ -5,14 +5,38 @@
 my $foo = '#XXX';
 # this comment is OK
 my $XXX = 'foo';
+my $SITE_XXX = 'foo';
+# Site_XXX is also OK
 
 #-----------------------------------------------------------------------------
 
-## name XXX Comments
-## failures 1
+## name Unacceptable Comments
+## failures 3
 ## cut
 
 # XXX I need to fix this comment
+# I need to FIXME this
+# TODO-Change this
+
+#-----------------------------------------------------------------------------
+
+## name Special Characters
+## parms { keywords => 'WE*RD' };
+## failures 0
+## cut
+
+# WEIRD
+# WERD
+
+#-----------------------------------------------------------------------------
+
+## name Special Characters failing
+## parms { keywords => 'WE*RD' };
+## failures 1
+## cut
+
+# WE*RD
+# WEIRD
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Exclude metachars since we're now using a regex.  Closes #21 